### PR TITLE
testing workflow to build and deploy libabigail container

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -1,0 +1,78 @@
+name: Build Deploy Container
+
+on:
+
+  # Always have a base image ready to go - this is a nightly build
+  schedule:
+    - cron: 0 3 * * *
+
+  # On push to main we build and deploy images
+  push: 
+    branches:
+      - master
+
+  # Do build to test works on PR
+  pull_request: []
+
+  # Publish packages on release
+  release:
+    types: [published] 
+ 
+jobs:
+  build:
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+
+        # Note: these pairs must match to
+        # https://rse-ops.github.io/docker-images/r/ghcr.io-rse-ops-gcc-ubuntu-22.04/
+        ubuntu: ["22.04"]
+        gcc: ["10.3.0"]
+
+    runs-on: ubuntu-latest
+    name: Build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Make Space For Build
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+
+      - name: Pull previous layers for cache
+        run: docker pull ghcr.io/woodard/libabigail-${{ matrix.ubuntu }}:latest || echo "No container to pull"
+
+      - name: Build Container
+        run: |
+           container=ghcr.io/woodard/libabigail-ubuntu-${{ matrix.ubuntu }}:latest
+           docker build --build-arg ubuntu_version=${{ matrix.ubuntu }} \
+                        --build-arg gcc_version=${{ matrix.gcc }} \
+                        -t ${container} .
+           docker tag ${container} ghcr.io/woodard/libabigail-ubuntu-${{ matrix.ubuntu }}:gcc-${{ matrix.gcc }}
+           docker tag ${container} ghcr.io/woodard/libabigail:latest
+
+      - name: GHCR Login
+        if: (github.event_name != 'pull_request')
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy
+        if: (github.event_name != 'pull_request')
+        run: |
+            docker push ghcr.io/woodard/libabigail:latest
+            docker push ghcr.io/woodard/libabigail-ubuntu-${{ matrix.ubuntu }}:latest
+            docker push ghcr.io/woodard/libabigail-ubuntu-${{ matrix.ubuntu }}:gcc-${{ matrix.gcc }}
+            
+      - name: Tag and Push Release
+        if: (github.event_name == 'release')
+        run: |
+            tag=${GITHUB_REF#refs/tags/}
+            echo "Tagging and releasing ghcr.io/woodard/libabigail:${tag}"
+            docker tag ghcr.io/woodard/libabigail:latest ghcr.io/woodard/libabigail:${tag}
+            docker push ghcr.io/woodard/libabigail:${tag}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+ARG ubuntu_version=22.04
+ARG gcc_version=10.3.0
+FROM ghcr.io/rse-ops/gcc-ubuntu-${ubuntu_version}:gcc-${gcc_version}
+
+# docker build -t ghcr.io/woodard/libabigail .
+
+# Install Libabigail to its own view
+WORKDIR /opt/abigail-env
+RUN . /opt/spack/share/spack/setup-env.sh && \
+    spack env create -d . && \
+    spack env activate . && \
+    spack add libabigail@master  && \
+    spack --debug install
+
+# Prepare a source extraction of libabigail at /src (intended to be overwritten by user)
+COPY . /src
+    
+# Second run - should have deps cached
+RUN . /opt/spack/share/spack/setup-env.sh && \
+
+    # This adds metadata for libabigail to spack.yaml
+    spack develop --path /src libabigail@master && \
+    spack --debug install
+    # At this point you can spack install, and bind the code to /code to develop
+
+# ensure libabigail stuffs always on the path    
+RUN cd /opt/abigail-env && \
+    spack env activate --sh -d . >> /etc/profile.d/z10_spack_environment.sh
+
+ENTRYPOINT ["/bin/bash", "--rcfile", "/etc/profile", "-l", "-c"]

--- a/README-DOCKER.md
+++ b/README-DOCKER.md
@@ -1,0 +1,53 @@
+# Libabigail Docker
+
+The [Dockerfile](Dockerfile) provided alongside the code provides a base container
+to build libabigail. We will build and deploy a container on:
+
+ - releases
+ - pushes to the main (master) branch
+
+### Usage
+
+Here is how to build the container. Note that we build so it belongs to the same
+namespace as the repository here. "ghcr.io" means "GitHub Container Registry" and
+is the [GitHub packages](https://github.com/features/packages) registry that supports
+ Docker images and other OCI artifacts.
+
+```bash
+$ docker build -t ghcr.io/woodard/libabigail .
+```
+
+Note that we use `ghcr.io/rse-ops/gcc-ubuntu-22.04:gcc-10.3.0` as the base image. If it's
+ever desired to build libabigail with different compilers or OS (across a matrix) we can do that too :)
+
+### Shell
+
+To shell into the container:
+
+```bash
+$ docker run -it ghcr.io/woodard/libabigail bash
+```
+
+Off the bat, you can find the abi executables:
+
+
+```bash
+# which abidiff
+/opt/abigail-env/.spack-env/view/bin/abidiff
+```
+
+That also means you can go to the environment in `/opt/abigail-env` and (given you
+have the source code bound to `/src`) build and test again.
+
+```bash
+$ spack install
+```
+
+And that's it! This workflow should make it easy to install development versions of libabigail with spack.
+We will also use the "production" containers to grab libraries in:
+
+```
+$ ls /opt/abigail-env/.spack-env/view/
+bin  include  lib  share
+```
+To run the libabigail action on (yes, very meta!)


### PR DESCRIPTION
This is testing an automated build (and deploy) workflow for libabigail containers.

- The repository packages (for your account @woodard) will need to be enabled for this to work on merge
- It currently will run on pull request, release, and scheduled nightly. We can remove the nightly if needed, but it doesn't hurt :)
- I've done the initial install of libabigail deps to hopefully be in its own layer, so when we pull the previous container that should be found in the cache (and save some build time).
- I added an instructions file README-DOCKER.md for docker instructions

And of course I'll update the PR with any issues! Once this builds and passes, and after ensuring packages are enabled, we will merge and that will deploy containers. Once we have containers I can add another workflow to run the libabigail checks against... libabigail! When that time comes I'll ask about which libs specifically we want to test.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>