### PR TITLE
Adding dispatch event to container build

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: 0 3 * * *
 
+  # Allow manual trigger of a build
+  workflow_dispatch:
+    inputs:
+      whatever:
+        description: 'This variable does not matter, its a GHA bug.'     
+        
   # On push to main we build and deploy images
   push: 
     branches:


### PR DESCRIPTION
This should create a button to deploy the workflow under actions. Note that we don't technically need a variable, but in practice I've found GitHub gets buggy sometimes without one so I added one we don't need.