### PR TITLE
adding a shared fedora base with needed deps (no multistage build)

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -34,7 +34,8 @@ jobs:
 
         # Dockerfiles to build, container names to use, and to tag as libabigail:latest?
         container: [["Dockerfile.fedora", "ghcr.io/woodard/libabigail-fedora", true],
-                    ["Dockerfile.ubuntu", "ghcr.io/woodard/libabigail-ubuntu-22.04", false]]
+                    ["Dockerfile.ubuntu", "ghcr.io/woodard/libabigail-ubuntu-22.04", false],
+                    ["Dockerfile.fedora-base", "ghcr.io/woodard/libabigail-fedora-base", false]]
  
     runs-on: ubuntu-latest
     name: Build

--- a/.github/workflows/libabigail.yaml
+++ b/.github/workflows/libabigail.yaml
@@ -3,8 +3,9 @@ on:
   pull_request: []
 
 jobs:
+
 #  get-release:
-#    container: ghcr.io/woodard/libabigail:2.1
+#    container: ghcr.io/woodard/libabigail-ubuntu-22.04:latest
 #    runs-on: ubuntu-latest
 #    steps:
 #    - name: Organize Files
@@ -27,7 +28,7 @@ jobs:
 
 
   get-latest:
-    container: ghcr.io/woodard/libabigail:latest
+    container: ghcr.io/woodard/libabigail-ubuntu-22.04:latest
     runs-on: ubuntu-latest
     steps:
     - name: Organize Files
@@ -49,7 +50,7 @@ jobs:
           /abi/libsystemd.so.0
 
   get-pr:
-    container: ghcr.io/woodard/libabigail:latest
+    container: ghcr.io/woodard/libabigail-ubuntu-22.04:latest
     runs-on: ubuntu-latest
     steps:
     - name: Build Pull Request

--- a/docker/Dockerfile.fedora-base
+++ b/docker/Dockerfile.fedora-base
@@ -1,0 +1,19 @@
+ARG fedora_version=latest
+# ARG fedora_version=35
+FROM fedora:${fedora_version} as builder
+
+# docker build -f docker/Dockerfile.fedora-base -t ghcr.io/woodard/libabigail-fedora-base .
+
+RUN dnf install -y \
+    autoconf \
+    automake \
+    cpio \
+    elfutils-devel \
+    gcc-c++ \
+    libtool \
+    libxml2-devel \
+    python3-koji \
+    python3-mock \
+    python3-pyxdg \
+    six \
+    wget

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -2,7 +2,7 @@ ARG ubuntu_version=22.04
 ARG gcc_version=10.3.0
 FROM ghcr.io/rse-ops/gcc-ubuntu-${ubuntu_version}:gcc-${gcc_version}
 
-# docker build -t ghcr.io/woodard/libabigail .
+# docker build -t ghcr.io/woodard/libabigail-ubuntu-22.04 .
 
 # Install Libabigail to its own view
 WORKDIR /opt/abigail-env


### PR DESCRIPTION
we want to do this for the fedora and testing container (coming in subsequent PR) to use.
Right now, we will need to reinstall the same deps because the fedora libabigail image is
a multistage build and does not provide them. Both the testing container and the current fedora
container can use this base container and build a bit faster!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>