### PR TITLE
Add an option ignore SONAME differences in libraries

### DIFF
--- a/doc/manuals/abicompat.rst
+++ b/doc/manuals/abicompat.rst
@@ -77,6 +77,10 @@ Options
    Do not show information about where in the *second shared library*
    the respective type was changed.
 
+️  * ``--ignore-soname``
+
+    Ignore differences in the SONAME when doing a comparison
+
   * ``--weak-mode``
 
     This triggers the weak mode of ``abicompat``.  In this mode, only

--- a/doc/manuals/abidiff.rst
+++ b/doc/manuals/abidiff.rst
@@ -310,6 +310,10 @@ Options
     Show sizes and offsets in decimal base.  This option is activated
     by default.
 
+  * ``--ignore-soname``
+
+    Ignore differences in the SONAME when doing a comparison
+
   *  ``--no-show-relative-offset-changes``
 
      Without this option, when the offset of a data member changes,

--- a/src/abg-comparison.cc
+++ b/src/abg-comparison.cc
@@ -10921,7 +10921,10 @@ compute_diff(const corpus_sptr	f,
 
   ctxt->set_corpus_diff(r);
 
-  r->priv_->sonames_equal_ = f->get_soname() == s->get_soname();
+  if(ctxt->show_soname_change())
+    r->priv_->sonames_equal_ = f->get_soname() == s->get_soname();
+  else
+    r->priv_->sonames_equal_ = true;
 
   r->priv_->architectures_equal_ =
     f->get_architecture_name() == s->get_architecture_name();

--- a/tools/abicompat.cc
+++ b/tools/abicompat.cc
@@ -74,6 +74,7 @@ public:
   bool			redundant_opt_set;
   bool			no_redundant_opt_set;
   bool			show_locs;
+  bool                  ignore_soname;
 
   options(const char* program_name)
     :prog_name(program_name),
@@ -85,7 +86,8 @@ public:
      show_redundant(true),
      redundant_opt_set(),
      no_redundant_opt_set(),
-     show_locs(true)
+     show_locs(true),
+     ignore_soname(false)
   {}
 }; // end struct options
 
@@ -112,6 +114,7 @@ display_usage(const string& prog_name, ostream& out)
     << "  --suppressions|--suppr <path> specify a suppression file\n"
     << "  --no-redundant  do not display redundant changes\n"
     << "  --no-show-locs  do now show location information\n"
+    << "  --ignore-soname  do not take the SONAMEs into account\n"
     << "  --redundant  display redundant changes (this is the default)\n"
     << "  --weak-mode  check compatibility between the application and "
     "just one version of the library.\n"
@@ -206,6 +209,8 @@ parse_command_line(int argc, char* argv[], options& opts)
 	}
       else if (!strcmp(argv[i], "--no-show-locs"))
 	opts.show_locs = false;
+      else if (!strcmp(argv[i], "--ignore-soname"))
+	opts.ignore_soname=true;
       else if (!strcmp(argv[i], "--help")
 	       || !strcmp(argv[i], "-h"))
 	{
@@ -277,6 +282,8 @@ create_diff_context(const options& opts)
   ctxt->show_linkage_names(true);
   ctxt->show_redundant_changes(opts.show_redundant);
   ctxt->show_locs(opts.show_locs);
+  // Intentional logic flip of ignore_soname
+  ctxt->show_soname_change(!opts.ignore_soname);
   ctxt->switch_categories_off
     (abigail::comparison::ACCESS_CHANGE_CATEGORY
      | abigail::comparison::COMPATIBLE_TYPE_CHANGE_CATEGORY

--- a/tools/abidiff.cc
+++ b/tools/abidiff.cc
@@ -78,6 +78,7 @@ struct options
   bool			no_default_supprs;
   bool			no_arch;
   bool			no_corpus;
+  bool                  ignore_soname;
   bool			leaf_changes_only;
   bool			fail_no_debug_info;
   bool			show_hexadecimal_values;
@@ -125,6 +126,7 @@ struct options
       no_default_supprs(),
       no_arch(),
       no_corpus(),
+      ignore_soname(false),
       leaf_changes_only(),
       fail_no_debug_info(),
       show_hexadecimal_values(),
@@ -205,6 +207,7 @@ display_usage(const string& prog_name, ostream& out)
        "default suppression specification\n"
     << " --no-architecture  do not take architecture in account\n"
     << " --no-corpus-path  do not take the path to the corpora into account\n"
+    << " --ignore-soname  do not take the SONAMEs into account\n"
     << " --fail-no-debug-info  bail out if no debug info was found\n"
     << " --leaf-changes-only|-l  only show leaf changes, "
     "so no change impact analysis (implies --redundant)\n"
@@ -404,6 +407,8 @@ parse_command_line(int argc, char* argv[], options& opts)
 	opts.no_arch = true;
       else if (!strcmp(argv[i], "--no-corpus-path"))
 	opts.no_corpus = true;
+      else if (!strcmp(argv[i], "--ignore-soname"))
+	opts.ignore_soname = true;
       else if (!strcmp(argv[i], "--fail-no-debug-info"))
 	opts.fail_no_debug_info = true;
       else if (!strcmp(argv[i], "--leaf-changes-only")
@@ -699,6 +704,8 @@ set_diff_context_from_opts(diff_context_sptr ctxt,
   ctxt->show_added_vars(opts.show_all_vars || opts.show_added_vars);
   ctxt->show_linkage_names(opts.show_linkage_names);
   ctxt->show_locs(opts.show_locs);
+  // Intentional logic flip of ignore_soname
+  ctxt->show_soname_change(!opts.ignore_soname);
   // So when we are showing only leaf changes, we want to show
   // redundant changes because of this: Suppose several functions have
   // their return type changed from void* to int*.  We want them all


### PR DESCRIPTION
There are rare use cases where we do not want to compare the SONAME when
testing libraries for compatiblity or diffing libraries. This adds an
option to ignore the SONAME when doing the comparison. In these cases,
we will edit the application's DT_NEEDED to point to the other library.

This reuses the show_soname_change() function and slightly changes its
meaning to not only control if the sonames are printed but also if
they are compared. There didn't seem to be any other users of this
function and slight semantic change seemed harmless.

   * doc/manuals/abicompat.rst - added new option
   * doc/manuals/abidiff.rst - added new option to manpage
   * tools/abicompat.cc - added new command line option and passed it
   to the diff_context.
   * tools/abidiff.cc - added new command line option and passed it
   to the diff_context.
   * src/abg-comparison.cc - don't bother comparing the sonames if
   you aren't going to print them.

Signed-off-by: Ben Woodard <woodard@redhat.com>