### PR TITLE
Fix typo in abipkgdiff manpage

### DIFF
--- a/doc/manuals/abipkgdiff.rst
+++ b/doc/manuals/abipkgdiff.rst
@@ -452,7 +452,7 @@ Options
     Emit verbose progress messages.
 
 
-  * ``self-check``
+  * ``--self-check``
 
     This is used to test the underlying Libabigail library.  When in
     used, the command expects only on input package, along with its


### PR DESCRIPTION
Add double dash to option name in man page. A minor typo.

        * doc/manuals/abipkgdiff.rst: add missing `--`

Signed-off-by: Ben Woodard <woodard@redhat.com>