### PR TITLE
Fix path in Dockerfile.test

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -25,4 +25,4 @@ RUN mkdir -p build && \
     -fasynchronous-unwind-tables -O2" LDFLAGS="-Wl,--no-undefined" \
     ../configure --prefix=/opt/libabigail --enable-rpm=yes && \
     make -j4 && \
-    make check ENABLE_SLOW_TEST=yes || (cat /tests/test-suite.log && exit 1)
+    make check ENABLE_SLOW_TEST=yes || (cat tests/test-suite.log && exit 1)


### PR DESCRIPTION
The path to the tests/test-suite.log is relative to the current
directory not an absolute path. Fix the path so that we can see which
test failed.

     * docker/Dockerfile.test

Signed-off-by: Ben Woodard <woodard@redhat.com>