### PR TITLE
Increment Library version

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,7 +47,7 @@ libabigail_la_SOURCES += abg-ctf-reader.cc
 endif
 
 libabigail_la_LIBADD = $(DEPS_LIBS) $(FTS_LIBS)
-libabigail_la_LDFLAGS = -lpthread -Wl,--as-needed -no-undefined
+libabigail_la_LDFLAGS = -lpthread -Wl,--as-needed -no-undefined -version-info 1:0:0
 
 CUSTOM_MACROS = -DABIGAIL_ROOT_SYSTEM_LIBDIR=\"${libdir}\"
 


### PR DESCRIPTION
Add library version to libabigail 2.0 to not cause problems with older
utilities and due to library version incompatibility. This will also stop
tools that look for libraries which have a different ABI but the same
version from complaining.

* src/Makefile.am

Signed-off-by: Ben Woodard <woodard@redhat.com>